### PR TITLE
Update reset to sys_reset

### DIFF
--- a/config/boards/arm/ahokore/ahokore.keymap
+++ b/config/boards/arm/ahokore/ahokore.keymap
@@ -89,7 +89,7 @@ behaviors {
 // | BT1 | BOOT|     |      |     |      |      |      |      |      |
 //             | CTL | ALT |  ENT | SPC | GUI  | CTL |
                         bindings = <
-   &bt BT_CLR   &reset      &trans  &trans &trans     &trans    &kp PG_DN &kp UP    &kp PG_UP &trans
+   &bt BT_CLR   &sys_reset  &trans  &trans &trans     &trans    &kp PG_DN &kp UP    &kp PG_UP &trans
    &bt BT_SEL 0 &kp K_CMENU &trans  &trans &trans     &kp HOME  &kp LEFT  &kp DOWN  &kp RIGHT &kp END
    &bt BT_SEL 1 &bootloader &trans  &trans &trans     &trans    &trans    &trans    &trans    &trans
    &trans   &trans    &trans     &trans   &trans   &trans


### PR DESCRIPTION
zmk renamed `reset` to `sys_reset` which breaks the build https://github.com/zmkfirmware/zmk/commit/35a1c5a3d44b92c050d28c0aca3d1cb9c7e53695